### PR TITLE
Bugfix: Tag Filters not Working

### DIFF
--- a/src/content/posts/angular-testing-observable-errors.mdx
+++ b/src/content/posts/angular-testing-observable-errors.mdx
@@ -1,6 +1,6 @@
 ---
 title: Testing Angular Service Methods that Return throwError() from a catchError()'s Callback
-datePublished: "2023-05-12"
+datePublished: "2023-05-22"
 author: Tom Latham
 description:
   Sometimes it's hard to reach and handle error cases when testing (with Jasmine) Angular services

--- a/src/pages/posts/BlogSearchPage.tsx
+++ b/src/pages/posts/BlogSearchPage.tsx
@@ -3,6 +3,7 @@ import { GetServerSideProps } from "next";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import Head from "next/head";
+import _ from "lodash";
 
 import Layout from "@/components/layout";
 import PostSearchListEntry from "@/components/postSearchListEntry";
@@ -29,17 +30,19 @@ const BlogSearchPage: React.FC<Props> = ({ frontmatterArray, allTags }) => {
   };
 
   const toggleTag = (tag: string) => {
+    let selectedTagsClone = _.cloneDeep(selectedTags);
     if (selectedTags.includes(tag)) {
-      setSelectedTags(selectedTags.filter((selectedTag) => selectedTag !== tag));
+      selectedTagsClone = selectedTagsClone.filter((selectedTag) => selectedTag !== tag);
     } else {
-      setSelectedTags([...selectedTags, tag]);
+      selectedTagsClone = [...selectedTags, tag];
     }
+
     // this can be removed once all the categories listed on the homepage have at least one post
-    setSelectedTags(
-      selectedTags.filter((selectedTag) => {
-        return allTags.includes(selectedTag);
-      })
-    );
+    selectedTagsClone = selectedTagsClone.filter((selectedTag) => {
+      return allTags.includes(selectedTag);
+    });
+
+    setSelectedTags(selectedTagsClone);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## What was the bug?

Tag filters weren't working correctly. Reproduced by:

1. Go to post search page.
2. Select a tag filter.

Intended result: The post list shows only those posts described by the selected filters.
Actual result: The post list includes all posts.

## How did you fix it?

I used Lodash's `cloneDeep()` to create a clone of the `selectedTags` state, such that multiple changes to that state could be applied within a single function. Otherwise, using multiple `setSelectedTags()`s in sequence does not work as desired. We have to make all changes to a clone of the state, and then call `setSelectedTags()` once, passing the modified clone as the new state argument.

## What else did you do?

I updated the published date on the post from #1. Thank you @Faolan7 for pointing that out.