### PR TITLE
Bugfixes | Post-Search Page Overflow in Chromium; Unnecessary Scrollbars; Unstyled Scrollbars in Chromium

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -15,7 +15,7 @@ const Layout: React.FC<Props> = ({ children }) => {
   const useDarkMode = useAppSelector(userPreferences.selectors.getUseDarkMode);
   useThemePreference(useDarkMode);
   return (
-    <div className="overflow-visible">
+    <div className="overflow-clip">
       <Head>
         <link
           rel="stylesheet"

--- a/src/content/components/kaTexComponent/KaTexComponent.tsx
+++ b/src/content/components/kaTexComponent/KaTexComponent.tsx
@@ -24,7 +24,9 @@ const KaTeXComponent: React.FC<Props> = ({ texExpression, options, className }) 
           display: inline-block;
           white-space: nowrap;
           max-width: 100%;
-          overflow-x: scroll;
+          width: 100%;
+          overflow-y: clip;
+          overflow-x: auto;
           text-align: initial;
         }
         .katex {

--- a/src/pages/posts/[id]/BlogPost.tsx
+++ b/src/pages/posts/[id]/BlogPost.tsx
@@ -49,7 +49,7 @@ const BlogPost: React.FC<Props> = ({ code, frontmatter }) => {
             <p className="text-left pb-4 text-xl dark:text-trim-dark text-secondary-light">
               {"Contents"}
             </p>
-            <div className="max-h-96 overflow-y-scroll">
+            <div className="max-h-96 overflow-y-auto">
               <BlogTOC />
             </div>
           </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -17,4 +17,22 @@ body * {
     @apply h-full;
     @apply dark:bg-back-dark bg-back-light;
   }
+  ::-webkit-scrollbar {
+    width: 5px;
+    height: 5px;
+  }
+
+  ::-webkit-scrollbar-track {
+    @apply dark:bg-[#F2F2F2] bg-[#ffffff];
+    border-radius: 2px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    @apply dark:bg-[#878787] bg-[#BDBDBD];
+    border-radius: 2px;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: #6e6e6e;
+  }
 }

--- a/src/styles/syntaxHighlighting.css
+++ b/src/styles/syntaxHighlighting.css
@@ -8,6 +8,7 @@
 /* Code block styles */
 pre {
   overflow-x: auto;
+  max-width: none;
 }
 
 /**
@@ -17,7 +18,7 @@ pre {
  */
 .code-highlight {
   float: left; /* 1 */
-  min-width: 100%; /* 2 */
+  min-width: min-content; /* 2 */
 }
 
 .code-line {


### PR DESCRIPTION

# 1. Post-Search Page Overflow in Chromium

## What was the bug?
On Chromium browsers, the post-search page was having visible horizontal overflow (past the navbar). This is obviously no good.

## How did you fix it?
In the `<Layout>` component, I changed the most ancestral `<div>`'s `overflow-visible` CSS (Tailwind) to `overflow-clip`.

# 2. Unnecessary Scrollbars

## What was the bug?
In blog-post pages, the tables of contents, some math in display mode and code snippets were rendering with unnecessary scrollbars, both horizontal and vertical.

## How did you fix it?
- For the TOC, I set the CSS on its containing `<div>` from ` overflow-y-scroll` to ` overflow-y-auto`.
- For the math (`<KaTeXComponent>`s with `displayMode: true`), I set horizontal overflow to `auto` and vertical overflow to `clip`. The horizontal scrolling is sometimes needed for really wide expressions, but the vertical scrolling before was never necessary.
- For the code snippets, I changed `syntaxHighlighting.css`: The `.code-highlight` class now has a minimum width of `min-content`, but `<pre>` elements have no maximum width. I'm not sure why, but it seemed before that the `code-highlight` classed elements were overflowing their ancestral `<pre>`s, and this is *a* way to stop that happening (maybe not the best way).

# 3. Unstyled Scrollbars in Chromium

## What was the bug?
This is more of a feature I suppose, but the default scrollbars in Chromium (using the WebKit rendering engine) look... well, plain enough that I'm considering the change a bugfix.

## How did you fix it?
In `globals.css` I added `::-webkit-scrollbar` styling.

