### PR TITLE
Feature | A More Useful README; Reading-Time Estimates for Posts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "cSpell.words": ["frontmatter"]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["frontmatter"]
+}

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -20,7 +20,9 @@ under GPLv3.
 
 # Other Files
 
-All other files are licensed under the MIT License.
+All other files are licensed under the MIT License using the following copyright notice:
+
+Copyright (c) 2023 Thomas Latham
 
 # License Texts
 

--- a/README.md
+++ b/README.md
@@ -1,115 +1,159 @@
 # Tom Latham Blog
 
+<!-- omit in toc -->
 ## Table of Contents
-+ [Project Structure](#project-structure)
-- [Use This Code as a Template for Your Own Blog](#use-this-code-as-a-template-for-your-own-blog)
+1. [Project Overview](#project-overview)
+2. [Project Structure](#project-structure)
+   1. [General Standards](#general-standards)
+   2. [The `src` Directory](#the-src-directory)
+   3. [Other Directories and Files](#other-directories-and-files)
+3. [Use This Code as a Template for Your Own Blog](#use-this-code-as-a-template-for-your-own-blog)
+   1. [Step 1: Clone the Repo, Set Up Your Own Repo, Get Dependencies](#step-1-clone-the-repo-set-up-your-own-repo-get-dependencies)
+   2. [Step 2: Personalize Your Blog's Content](#step-2-personalize-your-blogs-content)
+   3. [Step 3: Deploy Your Blog](#step-3-deploy-your-blog)
+
 
 ---
 
-I created this project primarily with Next.js and React to practice and demonstrate my programming skills. Blog posts are written in [MDX](https://mdxjs.com/), allowing me to embed interactive React components in Markdown, a simple, easy-to-read markup language. It really is the best of both worlds.
+## Project Overview
+
+I created this project primarily with Next.js, React and Tailwind to practice and demonstrate my programming skills. Blog posts are written in [MDX](https://mdxjs.com/), allowing me to embed interactive React components in Markdown, a simple, easy-to-read markup language. It really is the best of both worlds.
 
 The posts live on the server (I suppose I use GitHub as a CMS) and are also compiled and bundled server-side using [mdx-bundler](https://github.com/kentcdodds/mdx-bundler). Each blog-post page, in fact, is also [rendered on the server](https://nextjs.org/docs/pages/building-your-application/rendering/static-site-generation#static-generation-with-data) at build time, and the resulting HTML is served to clients and reused on each request.
 
-I also have some plain Markdown content for items in my portfolio, and that is served in a similar way. The differences are:
+I also have some plain Markdown content for items in my portfolio, and that is served in a similar
+way. Since it's just regular old Markdown though there's no need for compiling and bundling the
+content, so it simply gets passed in the server as plain text and rendered there with the help of
+[react-markdown](https://github.com/remarkjs/react-markdown).
 
-- (a.) There's no need for compiling and bundling the content since it's plain Markdown — it gets passed in the server as plain text and rendered there with the help of [react-markdown](https://github.com/remarkjs/react-markdown).
-- (b.) Instead of rendering at build time like each of the blog-post pages, the portfolio page is rendered [on every request](https://nextjs.org/docs/pages/building-your-application/rendering/server-side-rendering). (This doesn't seem necessary now that I'm writing about it; it rather seems that the portfolio page would be better off being rendered at build time since it doesn't ever need to re-pre-render with updated external data. For now, though, we'll just say we're using `getServerSideProps` as an exercise in Next.js capabilities.)
-
-Anyway, those are the basics of what's going on with this blog, and below I'll go into more details in case somebody wants learn more about the technologies used or build their own website.
+Those are the basics of what's going on with this blog; below I'll go into more details in case
+anybody wants learn more about how I have things organized or if they want to build a blog of their
+own using this code.
 
 ## Project Structure
 
-### `public`
+### General Standards
 
-This directory is used by Next.js for [serving static files](https://nextjs.org/docs/pages/building-your-application/optimizing/static-assets) in a conveniently-programmed way. In my own implementation, images owned by myself are in the `public/myImages` directory, and images I don't own are in the `public/otherImages` directory.
-
-### General Standards in `src`
-
-- For the most part every TypeScript file gets its own directory, with exports passed onto the directory's `index.ts` file.
+- For the most part, every TypeScript file gets its own directory, with exports passed onto the
+  directory's `index.ts` file.
 - All exports (default and named) are declared at the end of files.
+- Code is formatted according to the rules outlined in `.eslintrc.js` and `.prettierrc.js`.
 
-### `src/components`
+### The `src` Directory
+
+#### `src/components`
 
 Here we find all the from-scratch components used in the website, except those consumed in blog-post MDX files. The exception to this is the `<BlogPlot>` , which contains the large Plotly import so that posts that use it don't have such a large amount of data, since this [strains the client](https://nextjs.org/docs/messages/large-page-data).
 
 An important detail is that components used exclusively on the `posts/id` page have names beginning with "Blog." The [`<Layout>`](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts#root-layout-required) component is also special and worth mentioning since it's a parent of every page.
 
-### `src/constants`
+#### `src/constants`
 
 For things that don't change and are used in multiple parts of the application.
 
-### `src/content`
+#### `src/content`
 
 This directory is basically the "database" for the application. Here we have the MDX blog posts, the components embedded into that MDX and also the Markdown files for portfolio items.
 
-### `src/contentRetrieval`
+#### `src/contentRetrieval`
 
 If `src/content` is the database of the app, then this directory is like the API (in a way, since everything that consumes the data returned from here still gets rendered on the server anyway). Retrieving portfolio items is fairly straightforward, since our use-case is only ever getting all of them, but post retrieval is a bit more involved, since sometimes we only want the frontmatter or a filtered subset of the posts.
 
 If I ever move away from using GitHub as my CMS and instead set up a separate back end to serve data from a database, then this directory will probably hold all the functions for hitting that API for reusability purposes.
 
-### `src/ducks`
+#### `src/ducks`
 
 The code for managing application state via the [Redux ducks pattern](https://github.com/erikras/ducks-modular-redux). Right now the only application state we're managing is the `userPreferences` slice with the `useDarkMode` state and `toggleUseDarkMode`
 
 reducer.
 
-### `src/interfaces`
+#### `src/interfaces`
 
 Any TypeScript interfaces that get reused.
 
-### `src/pages`
+#### `src/pages`
 
 This directory implements the Next.js [Pages
 Router](https://nextjs.org/docs/pages/building-your-application/routing/pages-and-layouts).
 Eventually I want to migrate to the [App Router](https://nextjs.org/docs/app).
 
-### `src/redux`
+#### `src/redux`
 
 Here you'll find the Redux store and root reducer.
 
-### `src/styles`
+#### `src/styles`
 
 Here we have global styling for the whole application (e.g., smooth scrolling and Webkit stuff) and
 also the syntax-highlighting rules for code snippets in blog posts.
 
-### `src/types`
+#### `src/types`
 
 This directory is for custom types, in case some dependency isn't typed or we only want a type
 declaration for a partial bundle of a dependency, as seen
 [here](https://dev.to/dheerajmurali/building-a-responsive-chart-in-react-with-plotly-js-4on8).
 
-### `src/utils`
+#### `src/utils`
 
 We have here shared tools for formatting and general usage, as well as custom React hooks.
 
-### Noteworthy Root-Directory Files
+### Other Directories and Files
 
-Most of the configuration files are just a matter of reading the documentation provided for them to
-see what they're doing for the application. In `next.config.js` we have some stuff going on to make
-SVGs render as React components. Also, in `tailwind.config.js` is the palette definition for the
-application, which may be of particular use if you're going to use this codebase as a template for
-your own blog.
+#### The `public` Directory
+
+This directory is used by Next.js for [serving static
+files](https://nextjs.org/docs/pages/building-your-application/optimizing/static-assets) in a
+conveniently-programmed way. In my own implementation, images owned by myself are in the
+`public/myImages` directory, and images I don't own are in the `public/otherImages` directory.
+
+#### Root-Directory Configuration Files
+Understanding most of the config files in the root directory is just a matter of reading the
+official documentation provided for them to see what they're doing for the application. In
+`next.config.js` we have some stuff going on to make SVGs render as React components. Also, in
+`tailwind.config.js` is the palette definition for the application, which may be of particular use
+if you're going to use this codebase as a template for your own blog.
 
 ## Use This Code as a Template for Your Own Blog
 
-### Step 1: Clone the Repo and Get Dependencies
+### Step 1: Clone the Repo, Set Up Your Own Repo, Get Dependencies
+
+#### Clone the Code
 
 First, open a terminal (e.g., Git Bash) in some directory where you want the code to live locally.
-Then enter the command
+Then pick a name for the directory that will store the codebase (e.g., `my-blog-app`) and enter the
+command
 
 ```bash
-git clone https://github.com/ThomasLatham/tlb-app.git
+git clone https://github.com/ThomasLatham/tlb-app.git my-blog-app
+```
+After that, enter the command `cd my-blog-app` to navigate into the project's root directory.
+
+(In both the commands above, you can replace the `my-blog-app` part with whatever directory name you
+chose.)
+
+From there, go into the `package.json` file and change the value of the `name` property to something of your
+choosing (e.g., `"my-blog-app"`).
+
+#### Set Up Your Own GitHub Repository
+
+[Create a repo in GitHub](https://docs.github.com/en/get-started/quickstart/create-a-repo) to house
+your blog's code remotely. After that, enter the following commands in the terminal from before to
+point your local repo at your new remote one:
+```bash
+git remote rename origin upstream
+git remote add origin <URL of the repo you just created>
+git push origin master
 ```
 
-Then, make sure you have `node` and `yarn` installed globally on your machine. You can check this by
+#### Get Dependencies and Run Locally
+
+Make sure you have `node` and `yarn` installed globally on your machine. You can check this by
 entering `node -v` and `yarn -v` in the terminal. To install dependencies for the application, run
 `yarn`.
 
 Now you can run the application locally in development mode with the command `yarn dev`, after which
 you can visit `localhost:3000` to see the website.
 
-### Step 2: Personalize Your Blog
+### Step 2: Personalize Your Blog's Content
 
 #### Logo and Icon
 
@@ -126,8 +170,8 @@ create a blog post, make a new MDX file in that same directory (e.g., `my-first-
 filename (without the `.mdx` extension) will be used as the slug for the post URL, so I
 recommend-using-kebab-case-for-that.
 
-Inside that file you just
-created, at the very top you'll want to have some frontmatter in the following format:
+Inside that file you just created, at the very top you'll want to have some frontmatter in the
+following format:
 
 ```Markdown
 ---
@@ -135,21 +179,25 @@ title: My First Post!
 datePublished: "2024-01-03"
 author: Finn Mertins
 description: A short description for your first blog post.
-tags: ["Tag1", "Tag2"]
+tags: ["someTag", "anotherTag"]
 ---
 ```
 
-Below that you can add any Markdown you want for post's content. You don't really have to do
-anything else besides this to make a new post because the application automatically does the rest
-for you, including creating a listing in the post-search page and making the post page itself.
-There's some fine-tuning you can do though, if you want:
+The above is just a template, so feel free to change up the fields to your liking.
+
+Below that you can add any Markdown or React components you want for your post's content. You don't
+really have to do anything else besides this to make a new post because the application
+automatically does the rest for you, from creating a listing and tag-filter buttons in the
+post-search page to styling the post itself and the creating its table of contents. There's some
+fine-tuning you can do though, if you want:
 - To change the way code snippets are displayed, you'll want to check out and play with the
   `src/styles/syntaxHighlighting.css` file. Some code-snippet styling is also done in
   `tailwind.config.js` in the root directory, but that's just keeping Tailwind from wrapping every
   snippet in quotes.
 - To change the depth of the table of contents, you'll want to take a look at the `useHeadingsData()`
   function in `src/utils/hooks/hooks.ts`. It looks like:
-  ```TypeScript
+
+```TypeScript
   const useHeadingsData = () => {
   const [nestedHeadings, setNestedHeadings] = useState<HeadingWithNestedHeadings[]>([]);
 
@@ -163,10 +211,74 @@ There's some fine-tuning you can do though, if you want:
   return { nestedHeadings };
 };
 ```
-Change the argument of `document.querySelectorAll()` to get the desired TOC depth you're after. For example, if you only one top-level headings to be included in the TOC, then the argument to that function would just be `"h1"`. If you wanted a depth of three, though, then you could pass `"h1, h2, h3"` as the argument.
 
-### Portfolio
+Change the argument of `document.querySelectorAll()` to get the desired TOC depth you're after. For
+example, if you only want top-level headings to be included in the TOC, then the argument to that
+function would just be `"h1"`. If you wanted a depth of three, though, then you could pass `"h1, h2,
+h3"` as the argument.
 
-### Color Palette
+#### Portfolio
 
-## Deploying
+If you *don't* want a portfolio on your website, follow these steps:
+- Delete the `src/pages/portfolio` directory so that Next.js doesn't create a route for the page.
+- In `src/constants/index.ts`, remove the `["Portfolio", "/portfolio"]` element from the
+  `NAV_OPTIONS` array so that the "Portfolio" option doesn't appear in the navbar and the footer.
+
+If you *do* want a portfolio, follow these steps (the example for which follow my arbitrary naming
+conventions):
+- Delete the directories which currently reside in the `src/content/portfolioItems` directory.
+- Create a new directory there for your first portfolio item, (e.g., `dragonTracker`).
+- Inside that directory create a **single** Markdown file (e.g., `dt-info.md`) to hold the content
+  of your portfolio item. It's important that there is precisely one Markdown file in the directory.
+- Put a PNG in the same directory that will act as the image for the portfolio card (see [my
+  portfolio](https://www.tomlatham.blog/portfolio) for an example). The image should be roughly
+  square (same height and width dimensions) in order for it to not get distorted. Name it, for
+  example, `dt-image.png`.
+- At the top of your Markdown file, create frontmatter according to the following format:
+
+  ```Markdown
+  ---
+  id: "dragon-tracker"
+  title: "Dragon Tracker"
+  role: "Creator"
+  description:"An application I made to globally geolocate dragons and estimate the values of their gold hoards."
+  cardImage: "dt-image.png"
+  ---
+  ```
+
+  It's important that the value of the `cardImage` field matches the name and file extension on the
+  card image you placed in the portfolio item's directory. I also recommend for readability keeping
+  the value of the `id` field in kebab-case since the portfolio item's URL will display as
+  `www.yourblog.com/porfolio#dragon-tracker`.
+
+After following these steps, you should have a working portfolio page that contains your first
+portfolio item.
+
+#### Color Palette
+
+To change the colors for the light and dark themes in your blog, open the `tailwind.config.js` file
+in the project's root directory and modify the values of the properties in the `theme.colors`
+property. For example, if you wanted to change the primary color of the blog's light theme to white,
+then you would set the value of `theme.colors["primary-light"]` to `#ffffff`. To read more, check
+out [Tailwind's Theme Configuration documentation](https://tailwindcss.com/docs/theme).
+
+### Step 3: Deploy Your Blog
+
+#### Push Your Changes to Remote
+
+With your GitHub repository set up and your blog's content tailored to your liking, you're almost ready
+deploy your blog. To make sure your deployment reflects all the changes you just made, push those
+changes to remote with the following commands:
+
+```bash
+git add .
+git commit -m "initial commit"
+git push
+```
+
+#### Deploy to Vercel
+
+I could describe this process in detail, but I'd basically just be rewriting what the awesome folks
+at Vercel have already prepared in their [Deploying Your Next.js
+App](https://nextjs.org/learn/basics/deploying-nextjs-app/deploy) documentation. After you follow
+the steps outlined there, your blog should be live and bussin'.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
    2. [The `src` Directory](#the-src-directory)
    3. [Other Directories and Files](#other-directories-and-files)
 3. [Use This Code as a Template for Your Own Blog](#use-this-code-as-a-template-for-your-own-blog)
-   1. [Step 1: Clone the Repo, Set Up Your Own Repo, Get Dependencies](#step-1-clone-the-repo-set-up-your-own-repo-get-dependencies)
+   1. [Step 1: Clone the Repo and Get Dependencies](#step-1-clone-the-repo-and-get-dependencies)
    2. [Step 2: Personalize Your Blog's Content](#step-2-personalize-your-blogs-content)
    3. [Step 3: Deploy Your Blog](#step-3-deploy-your-blog)
 
@@ -114,9 +114,9 @@ if you're going to use this codebase as a template for your own blog.
 
 ## Use This Code as a Template for Your Own Blog
 
-### Step 1: Clone the Repo, Set Up Your Own Repo, Get Dependencies
+### Step 1: Clone the Repo and Get Dependencies
 
-#### Clone the Code
+#### Clone the Repo
 
 First, open a terminal (e.g., Git Bash) in some directory where you want the code to live locally.
 Then pick a name for the directory that will store the codebase (e.g., `my-blog-app`) and enter the
@@ -133,17 +133,6 @@ chose.)
 From there, go into the `package.json` file and change the value of the `name` property to something of your
 choosing (e.g., `"my-blog-app"`).
 
-#### Set Up Your Own GitHub Repository
-
-[Create a repo in GitHub](https://docs.github.com/en/get-started/quickstart/create-a-repo) to house
-your blog's code remotely. After that, enter the following commands in the terminal from before to
-point your local repo at your new remote one:
-```bash
-git remote rename origin upstream
-git remote add origin <URL of the repo you just created>
-git push origin master
-```
-
 #### Get Dependencies and Run Locally
 
 Make sure you have `node` and `yarn` installed globally on your machine. You can check this by
@@ -154,6 +143,27 @@ Now you can run the application locally in development mode with the command `ya
 you can visit `localhost:3000` to see the website.
 
 ### Step 2: Personalize Your Blog's Content
+
+#### License (Important!)
+
+If you plan to open-source your blog's code and/or release the blog to the public, then please
+follow these steps to ensure licensing is done correctly:
+1. Open `LICENSE.md` in the project's root directory.
+2. Remove everything from the top of the file down to (but not including) the `# License Texts`
+   heading.
+3. Remove the `## GPLv3` subheading (and its content) under the `## MIT License` subheading.
+4. At the top of the file add the following section:
+   ```Markdown
+   # Third-Party Software
+
+   ## Thomas Latham
+
+   Copyright (c) 2023 Thomas Latham
+
+   License: MIT
+   ```
+5. If you want to open-source your code, then [choose a license](https://choosealicense.com/) and
+   modify the `LICENSE.md` file to reflect your choice.
 
 #### Logo and Icon
 
@@ -263,6 +273,16 @@ then you would set the value of `theme.colors["primary-light"]` to `#ffffff`. To
 out [Tailwind's Theme Configuration documentation](https://tailwindcss.com/docs/theme).
 
 ### Step 3: Deploy Your Blog
+
+#### Set Up Your Own GitHub Repository
+
+[Create a repo in GitHub](https://docs.github.com/en/get-started/quickstart/create-a-repo) to house
+your blog's code remotely. After that, enter the following commands in the terminal from before to
+point your local repo at your new remote one:
+
+```bash
+git remote set-url origin <URL of the repo you just created>
+```
 
 #### Push Your Changes to Remote
 

--- a/README.md
+++ b/README.md
@@ -165,3 +165,8 @@ There's some fine-tuning you can do though, if you want:
 ```
 Change the argument of `document.querySelectorAll()` to get the desired TOC depth you're after. For example, if you only one top-level headings to be included in the TOC, then the argument to that function would just be `"h1"`. If you wanted a depth of three, though, then you could pass `"h1, h2, h3"` as the argument.
 
+### Portfolio
+
+### Color Palette
+
+## Deploying

--- a/README.md
+++ b/README.md
@@ -1,13 +1,76 @@
-## Project Name & Pitch
+# Tom Latham Blog
 
-Tom Latham Blog
+I created this project primarily with Next.js and React to practice and demonstrate my programming
+skills. Blog posts are written in [MDX](https://mdxjs.com/), allowing me to embed interactive React
+components in Markdown, a simple, easy-to-read markup language. It really is the best of both
+worlds.
 
-A website for blogging. Specifically, the website for blogging that I created with the intent of
-making interactive blog posts.
+The posts live on the server (I suppose I use GitHub as a CMS) and are also compiled and bundled
+server-side using [mdx-bundler](https://github.com/kentcdodds/mdx-bundler). Each blog-post page
+that, in fact, is also [rendered on the
+server](https://nextjs.org/docs/pages/building-your-application/rendering/static-site-generation#static-generation-with-data)
+at build time, and the resulting HTML is served to clients and reused on each request.
 
-## Project Status
+I also have some plain Markdown content for items in my portfolio, and that is served in a similar
+way. The differences are:
+* (a.) There's no need for compiling and bundling the content since it's plain Markdown — it gets
+  passed in the server as plain text and rendered there via
+  [react-markdown](https://github.com/remarkjs/react-markdown).
+* (b.) Instead of rendering at build time like each of the blog-post pages, the portfolio page is
+  rendered [on every
+  request](https://nextjs.org/docs/pages/building-your-application/rendering/server-side-rendering).
+  (This doesn't seem necessary now that I'm writing about it; it rather seems that the portfolio
+  page would be better off being rendered at build time since it doesn't ever need to re-pre-render
+  with updated external data. For now, though, we'll just say we're using `getServerSideProps` as an
+  exercise in Next.js capabilities.)
 
-Released!
+Anyway, those are the basics of what's going on with this blog, and below I'll go into more details in
+case somebody wants learn more about the technologies used or build their own website.
+
+## Project Structure
+
+### `public`
+
+This directory is used by Next.js for [serving static
+files](https://nextjs.org/docs/pages/building-your-application/optimizing/static-assets) in a
+conveniently-programmed way. In my own implementation, images owned by myself are in the
+`public/myImages` directory, and images I don't own are in the `public/otherImages` directory.
+
+### General Standards in `src`
+
+* For the most part every TypeScript file gets its own directory, with exports passed onto the
+  directory's `index.ts` file.
+* All exports (default and named) are declared at the end of files.
+
+### `src/components`
+
+Here we find all the from-scratch components used in the website, except those consumed in blog-post
+MDX files. The exception to this is the `<BlogPlot>` , which contains the large Plotly import so that
+posts that use it don't have such a large amount of data, since this [strains the
+client](https://nextjs.org/docs/messages/large-page-data).
+
+An important detail is that components used exclusively on the `posts/id` page have names beginning
+with "Blog." The
+[ `<Layout>` ](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts#root-layout-required)
+component is also special and worth mentioning since it's a parent of every page.
+
+### `src/constants`
+
+For things that don't change and are used in multiple parts of the application.
+
+### `src/content`
+
+This directory is basically the "database" for the application. Here we have the MDX blog posts, the
+components embedded into that MDX and also the Markdown files for portfolio items.
+
+### `src/contentRetrieval`
+
+If `src/content` is the database of the app, then this directory is the API. Retrieving portfolio
+items is fairly straightforward, since our use-case is only ever getting all of them, but post
+retrieval is a bit more involved, since sometimes we only want the frontmatter or a filtered subset
+of the posts.
+
+## Use This Code as a Template for Your Own Blog
 
 ## Installation and Setup Instructions
 
@@ -15,12 +78,12 @@ Clone down this repository. You will need `node` and `yarn` installed globally o
 
 Installation:
 
-`yarn`
+ `yarn`
 
 To Start Server:
 
-`yarn dev`
+ `yarn dev`
 
 To Visit App:
 
-`localhost:3000`
+ `localhost:3000`

--- a/README.md
+++ b/README.md
@@ -1,58 +1,39 @@
 # Tom Latham Blog
+<!-- omit in toc -->
+## Table of Contents
++ [Project Structure](#project-structure)
+- [Use This Code as a Template for Your Own Blog](#use-this-code-as-a-template-for-your-own-blog)
++ [Installation and Setup Instructions](#installation-and-setup-instructions)
 
-I created this project primarily with Next.js and React to practice and demonstrate my programming
-skills. Blog posts are written in [MDX](https://mdxjs.com/), allowing me to embed interactive React
-components in Markdown, a simple, easy-to-read markup language. It really is the best of both
-worlds.
+---
 
-The posts live on the server (I suppose I use GitHub as a CMS) and are also compiled and bundled
-server-side using [mdx-bundler](https://github.com/kentcdodds/mdx-bundler). Each blog-post page
-that, in fact, is also [rendered on the
-server](https://nextjs.org/docs/pages/building-your-application/rendering/static-site-generation#static-generation-with-data)
-at build time, and the resulting HTML is served to clients and reused on each request.
+I created this project primarily with Next.js and React to practice and demonstrate my programming skills. Blog posts are written in [MDX](https://mdxjs.com/), allowing me to embed interactive React components in Markdown, a simple, easy-to-read markup language. It really is the best of both worlds.
 
-I also have some plain Markdown content for items in my portfolio, and that is served in a similar
-way. The differences are:
-* (a.) There's no need for compiling and bundling the content since it's plain Markdown — it gets
-  passed in the server as plain text and rendered there via
-  [react-markdown](https://github.com/remarkjs/react-markdown).
-* (b.) Instead of rendering at build time like each of the blog-post pages, the portfolio page is
-  rendered [on every
-  request](https://nextjs.org/docs/pages/building-your-application/rendering/server-side-rendering).
-  (This doesn't seem necessary now that I'm writing about it; it rather seems that the portfolio
-  page would be better off being rendered at build time since it doesn't ever need to re-pre-render
-  with updated external data. For now, though, we'll just say we're using `getServerSideProps` as an
-  exercise in Next.js capabilities.)
+The posts live on the server (I suppose I use GitHub as a CMS) and are also compiled and bundled server-side using [mdx-bundler](https://github.com/kentcdodds/mdx-bundler). Each blog-post page, in fact, is also [rendered on the server](https://nextjs.org/docs/pages/building-your-application/rendering/static-site-generation#static-generation-with-data) at build time, and the resulting HTML is served to clients and reused on each request.
 
-Anyway, those are the basics of what's going on with this blog, and below I'll go into more details in
-case somebody wants learn more about the technologies used or build their own website.
+I also have some plain Markdown content for items in my portfolio, and that is served in a similar way. The differences are:
+
+- (a.) There's no need for compiling and bundling the content since it's plain Markdown — it gets passed in the server as plain text and rendered there with the help of [react-markdown](https://github.com/remarkjs/react-markdown).
+- (b.) Instead of rendering at build time like each of the blog-post pages, the portfolio page is rendered [on every request](https://nextjs.org/docs/pages/building-your-application/rendering/server-side-rendering). (This doesn't seem necessary now that I'm writing about it; it rather seems that the portfolio page would be better off being rendered at build time since it doesn't ever need to re-pre-render with updated external data. For now, though, we'll just say we're using `getServerSideProps` as an exercise in Next.js capabilities.)
+
+Anyway, those are the basics of what's going on with this blog, and below I'll go into more details in case somebody wants learn more about the technologies used or build their own website.
 
 ## Project Structure
 
 ### `public`
 
-This directory is used by Next.js for [serving static
-files](https://nextjs.org/docs/pages/building-your-application/optimizing/static-assets) in a
-conveniently-programmed way. In my own implementation, images owned by myself are in the
-`public/myImages` directory, and images I don't own are in the `public/otherImages` directory.
+This directory is used by Next.js for [serving static files](https://nextjs.org/docs/pages/building-your-application/optimizing/static-assets) in a conveniently-programmed way. In my own implementation, images owned by myself are in the `public/myImages` directory, and images I don't own are in the `public/otherImages` directory.
 
 ### General Standards in `src`
 
-* For the most part every TypeScript file gets its own directory, with exports passed onto the
-  directory's `index.ts` file.
-* All exports (default and named) are declared at the end of files.
+- For the most part every TypeScript file gets its own directory, with exports passed onto the directory's `index.ts` file.
+- All exports (default and named) are declared at the end of files.
 
 ### `src/components`
 
-Here we find all the from-scratch components used in the website, except those consumed in blog-post
-MDX files. The exception to this is the `<BlogPlot>` , which contains the large Plotly import so that
-posts that use it don't have such a large amount of data, since this [strains the
-client](https://nextjs.org/docs/messages/large-page-data).
+Here we find all the from-scratch components used in the website, except those consumed in blog-post MDX files. The exception to this is the `<BlogPlot>` , which contains the large Plotly import so that posts that use it don't have such a large amount of data, since this [strains the client](https://nextjs.org/docs/messages/large-page-data).
 
-An important detail is that components used exclusively on the `posts/id` page have names beginning
-with "Blog." The
-[ `<Layout>` ](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts#root-layout-required)
-component is also special and worth mentioning since it's a parent of every page.
+An important detail is that components used exclusively on the `posts/id` page have names beginning with "Blog." The [`<Layout>`](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts#root-layout-required) component is also special and worth mentioning since it's a parent of every page.
 
 ### `src/constants`
 
@@ -60,26 +41,17 @@ For things that don't change and are used in multiple parts of the application.
 
 ### `src/content`
 
-This directory is basically the "database" for the application. Here we have the MDX blog posts, the
-components embedded into that MDX and also the Markdown files for portfolio items.
+This directory is basically the "database" for the application. Here we have the MDX blog posts, the components embedded into that MDX and also the Markdown files for portfolio items.
 
 ### `src/contentRetrieval`
 
-If `src/content` is the database of the app, then this directory is like the API (in a way, since
-everything that consumes the data returned from here still gets rendered on the server anyway).
-Retrieving portfolio items is fairly straightforward, since our use-case is only ever getting all of
-them, but post retrieval is a bit more involved, since sometimes we only want the frontmatter or a
-filtered subset of the posts.
+If `src/content` is the database of the app, then this directory is like the API (in a way, since everything that consumes the data returned from here still gets rendered on the server anyway). Retrieving portfolio items is fairly straightforward, since our use-case is only ever getting all of them, but post retrieval is a bit more involved, since sometimes we only want the frontmatter or a filtered subset of the posts.
 
-If I ever move away from using GitHub as my CMS and instead set up a separate back end to serve data
-from a database, then this directory will probably hold all the functions for hitting that API for
-reusability purposes.
+If I ever move away from using GitHub as my CMS and instead set up a separate back end to serve data from a database, then this directory will probably hold all the functions for hitting that API for reusability purposes.
 
 ### `src/ducks`
 
-The code for managing application state via the [Redux ducks
-pattern](https://github.com/erikras/ducks-modular-redux). Right now the only application state we're
-managing is the `userPreferences` slice with the `useDarkMode` state and `toggleUseDarkMode`
+The code for managing application state via the [Redux ducks pattern](https://github.com/erikras/ducks-modular-redux). Right now the only application state we're managing is the `userPreferences` slice with the `useDarkMode` state and `toggleUseDarkMode`
 
 reducer.
 
@@ -97,12 +69,12 @@ Clone down this repository. You will need `node` and `yarn` installed globally o
 
 Installation:
 
- `yarn`
+`yarn`
 
 To Start Server:
 
- `yarn dev`
+`yarn dev`
 
 To Visit App:
 
- `localhost:3000`
+`localhost:3000`

--- a/README.md
+++ b/README.md
@@ -277,18 +277,15 @@ out [Tailwind's Theme Configuration documentation](https://tailwindcss.com/docs/
 #### Set Up Your Own GitHub Repository
 
 [Create a repo in GitHub](https://docs.github.com/en/get-started/quickstart/create-a-repo) to house
-your blog's code remotely. After that, enter the following commands in the terminal from before to
-point your local repo at your new remote one:
+your blog's code remotely. After that, execute the following commands to point your local repo at
+your new remote one:
 
 ```bash
 git remote set-url origin <URL of the repo you just created>
 ```
 
-#### Push Your Changes to Remote
-
-With your GitHub repository set up and your blog's content tailored to your liking, you're almost ready
-deploy your blog. To make sure your deployment reflects all the changes you just made, push those
-changes to remote with the following commands:
+Then, to make sure your deployment reflects all the changes you just made, push those changes to
+remote with the following commands:
 
 ```bash
 git add .
@@ -298,7 +295,10 @@ git push
 
 #### Deploy to Vercel
 
-I could describe this process in detail, but I'd basically just be rewriting what the awesome folks
-at Vercel have already prepared in their [Deploying Your Next.js
-App](https://nextjs.org/learn/basics/deploying-nextjs-app/deploy) documentation. After you follow
-the steps outlined there, your blog should be live and bussin'.
+With your GitHub repository set up and up to date with your tailored blog content, you're ready to
+deploy with Vercel. I could describe this process in detail, but I'd basically just be rewriting
+what the awesome folks at Vercel have already prepared in their [Deploying Your Next.js
+App](https://nextjs.org/learn/basics/deploying-nextjs-app/deploy) documentation. Of course there are
+other deployment options, but Vercel makes the process very simple (and it's the option I chose).
+After you follow the steps outlined in that guide, your blog should be live. Congratulations on
+making a blog!

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Tom Latham Blog
-<!-- omit in toc -->
+
 ## Table of Contents
 + [Project Structure](#project-structure)
 - [Use This Code as a Template for Your Own Blog](#use-this-code-as-a-template-for-your-own-blog)
-+ [Installation and Setup Instructions](#installation-and-setup-instructions)
 
 ---
 
@@ -61,20 +60,108 @@ Any TypeScript interfaces that get reused.
 
 ### `src/pages`
 
+This directory implements the Next.js [Pages
+Router](https://nextjs.org/docs/pages/building-your-application/routing/pages-and-layouts).
+Eventually I want to migrate to the [App Router](https://nextjs.org/docs/app).
+
+### `src/redux`
+
+Here you'll find the Redux store and root reducer.
+
+### `src/styles`
+
+Here we have global styling for the whole application (e.g., smooth scrolling and Webkit stuff) and
+also the syntax-highlighting rules for code snippets in blog posts.
+
+### `src/types`
+
+This directory is for custom types, in case some dependency isn't typed or we only want a type
+declaration for a partial bundle of a dependency, as seen
+[here](https://dev.to/dheerajmurali/building-a-responsive-chart-in-react-with-plotly-js-4on8).
+
+### `src/utils`
+
+We have here shared tools for formatting and general usage, as well as custom React hooks.
+
+### Noteworthy Root-Directory Files
+
+Most of the configuration files are just a matter of reading the documentation provided for them to
+see what they're doing for the application. In `next.config.js` we have some stuff going on to make
+SVGs render as React components. Also, in `tailwind.config.js` is the palette definition for the
+application, which may be of particular use if you're going to use this codebase as a template for
+your own blog.
+
 ## Use This Code as a Template for Your Own Blog
 
-## Installation and Setup Instructions
+### Step 1: Clone the Repo and Get Dependencies
 
-Clone down this repository. You will need `node` and `yarn` installed globally on your machine.
+First, open a terminal (e.g., Git Bash) in some directory where you want the code to live locally.
+Then enter the command
 
-Installation:
+```bash
+git clone https://github.com/ThomasLatham/tlb-app.git
+```
 
-`yarn`
+Then, make sure you have `node` and `yarn` installed globally on your machine. You can check this by
+entering `node -v` and `yarn -v` in the terminal. To install dependencies for the application, run
+`yarn`.
 
-To Start Server:
+Now you can run the application locally in development mode with the command `yarn dev`, after which
+you can visit `localhost:3000` to see the website.
 
-`yarn dev`
+### Step 2: Personalize Your Blog
 
-To Visit App:
+#### Logo and Icon
 
-`localhost:3000`
+In the `public/myImages` directory, replace `logo.svg` with a logo of your own. I used
+[UXWing](https://uxwing.com) to find an attribution-free SVG, and then I used a mix of
+[GIMP](https://www.gimp.org/) and [Inkscape](https://inkscape.org/) to edit and add onto the SVG to
+my liking. I used [favicon.io](https://favicon.io/) to generate the icons in the `public/myImages/favicon`
+directory, using just the honeycomb symbol portion of my logo.
+
+#### Blog Posts
+
+Start by cleaning out the files in the `src/content/posts` directory. Once cleanup is done, to
+create a blog post, make a new MDX file in that same directory (e.g., `my-first-post.mdx`). The
+filename (without the `.mdx` extension) will be used as the slug for the post URL, so I
+recommend-using-kebab-case-for-that.
+
+Inside that file you just
+created, at the very top you'll want to have some frontmatter in the following format:
+
+```Markdown
+---
+title: My First Post!
+datePublished: "2024-01-03"
+author: Finn Mertins
+description: A short description for your first blog post.
+tags: ["Tag1", "Tag2"]
+---
+```
+
+Below that you can add any Markdown you want for post's content. You don't really have to do
+anything else besides this to make a new post because the application automatically does the rest
+for you, including creating a listing in the post-search page and making the post page itself.
+There's some fine-tuning you can do though, if you want:
+- To change the way code snippets are displayed, you'll want to check out and play with the
+  `src/styles/syntaxHighlighting.css` file. Some code-snippet styling is also done in
+  `tailwind.config.js` in the root directory, but that's just keeping Tailwind from wrapping every
+  snippet in quotes.
+- To change the depth of the table of contents, you'll want to take a look at the `useHeadingsData()`
+  function in `src/utils/hooks/hooks.ts`. It looks like:
+  ```TypeScript
+  const useHeadingsData = () => {
+  const [nestedHeadings, setNestedHeadings] = useState<HeadingWithNestedHeadings[]>([]);
+
+  useEffect(() => {
+    const headingElements: HTMLElement[] = Array.from(document.querySelectorAll("h1, h2"));
+
+    const newNestedHeadings = getNestedHeadings(headingElements);
+    setNestedHeadings(newNestedHeadings);
+  }, []);
+
+  return { nestedHeadings };
+};
+```
+Change the argument of `document.querySelectorAll()` to get the desired TOC depth you're after. For example, if you only one top-level headings to be included in the TOC, then the argument to that function would just be `"h1"`. If you wanted a depth of three, though, then you could pass `"h1, h2, h3"` as the argument.
+

--- a/README.md
+++ b/README.md
@@ -65,10 +65,29 @@ components embedded into that MDX and also the Markdown files for portfolio item
 
 ### `src/contentRetrieval`
 
-If `src/content` is the database of the app, then this directory is the API. Retrieving portfolio
-items is fairly straightforward, since our use-case is only ever getting all of them, but post
-retrieval is a bit more involved, since sometimes we only want the frontmatter or a filtered subset
-of the posts.
+If `src/content` is the database of the app, then this directory is like the API (in a way, since
+everything that consumes the data returned from here still gets rendered on the server anyway).
+Retrieving portfolio items is fairly straightforward, since our use-case is only ever getting all of
+them, but post retrieval is a bit more involved, since sometimes we only want the frontmatter or a
+filtered subset of the posts.
+
+If I ever move away from using GitHub as my CMS and instead set up a separate back end to serve data
+from a database, then this directory will probably hold all the functions for hitting that API for
+reusability purposes.
+
+### `src/ducks`
+
+The code for managing application state via the [Redux ducks
+pattern](https://github.com/erikras/ducks-modular-redux). Right now the only application state we're
+managing is the `userPreferences` slice with the `useDarkMode` state and `toggleUseDarkMode`
+
+reducer.
+
+### `src/interfaces`
+
+Any TypeScript interfaces that get reused.
+
+### `src/pages`
 
 ## Use This Code as a Template for Your Own Blog
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "rehype-rewrite": "^3.0.6",
     "rehype-slug": "^5.1.0",
     "remark-math": "^5.1.1",
+    "sharp": "^0.32.6",
     "superjson": "^1.12.2",
     "tailwindcss": "^3.2.7",
     "typescript": "4.9.5"

--- a/src/components/blogHeader/BlogHeader.tsx
+++ b/src/components/blogHeader/BlogHeader.tsx
@@ -1,32 +1,33 @@
 import React from "react";
-import { DateTime } from "luxon";
 
 import { formatDateString } from "@/utils/format";
+import { PostFrontmatter } from "@/interfaces";
 
 interface Props {
-  title: string;
-  datePublished: string;
-  lastUpdated?: string;
-  author: string;
-  tags: string[];
+  postFrontmatter: PostFrontmatter;
 }
 
-const BlogHeader: React.FC<Props> = ({ title, datePublished, lastUpdated, author, tags }) => {
-  const publishedString = `Published ${formatDateString(datePublished)}`;
+const BlogHeader: React.FC<Props> = ({ postFrontmatter }) => {
+  const publishedString = `Published ${formatDateString(postFrontmatter.datePublished)}`;
 
-  const updatedString = lastUpdated ? `Last updated ${formatDateString(lastUpdated)}` : "";
+  const updatedString = postFrontmatter.lastUpdated
+    ? `Last updated ${formatDateString(postFrontmatter.lastUpdated)}`
+    : "";
 
   return (
     <div className="flex flex-col">
       <div className="text-left">
-        <p className="text-5xl my-0">{title}</p>
+        <p className="text-5xl my-0">{postFrontmatter.title}</p>
       </div>
       <div className="text-left">
-        <p className="mt-2 mb-0">{`✍️ Written by ${author}`}</p>
+        <p className="mt-2 mb-0">{`✍️ Written by ${postFrontmatter.author}`}</p>
         <p className="my-0">
-          {`🗓️ ${publishedString}  ${lastUpdated ? " — " + updatedString : ""}`}
+          {`🗓️ ${publishedString} ${postFrontmatter.lastUpdated ? " — " + updatedString : ""}`}
         </p>
-        <p className="my-0">{`#️⃣ Tags: ${tags.join(", ")}`}</p>
+        <p className="my-0">{`🕑 Reading time: ${postFrontmatter.readingTime.toFixed(
+          0
+        )} minutes`}</p>
+        <p className="my-0">{`#️⃣ Tags: ${postFrontmatter.tags.join(", ")}`}</p>
       </div>
     </div>
   );

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -15,7 +15,7 @@ const Footer: React.FC = () => {
     <footer>
       <div className="w-full mx-auto max-w-screen-xl p-4 md:flex md:items-center md:justify-between">
         <span className="text-sm sm:text-center dark:text-trim-dark text-secondary-light">
-          © 2023 Tom Latham. All Rights Reserved.
+          © 2023 Thomas Latham. All Rights Reserved.
         </span>
         <ul className="flex flex-wrap items-center text-sm font-medium dark:text-trim-dark text-secondary-light mt-1 md:mt-0">
           {NAV_OPTIONS.map((option, idx) => {

--- a/src/components/postSearchListEntry/PostSearchListEntry.tsx
+++ b/src/components/postSearchListEntry/PostSearchListEntry.tsx
@@ -30,6 +30,7 @@ const PostSearchListEntry: React.FC<Props> = ({ postFM }) => {
         </div>
         <p className="mt-2 mb-0">{`✍️ By ${postFM.author}`}</p>
         <p className="my-0">{`🗓️ ${publishedString}`}</p>
+        <p className="my-0">{`🕑 ${postFM.readingTime.toFixed(0)} minutes`}</p>
         <p className="my-0">{`#️⃣ ${postFM.tags.join(", ")}`}</p>
       </div>
     </div>

--- a/src/contentRetrieval/posts/posts.ts
+++ b/src/contentRetrieval/posts/posts.ts
@@ -91,7 +91,7 @@ const fullPostResult = async (mdxFilepath: string) => {
     frontmatter: {
       ...frontmatter,
       wordCount: sourceText.split(/\s+/gu).length,
-      readingTime: readingTime(sourceText),
+      readingTime: readingTime(sourceText).minutes,
     },
   };
 };
@@ -122,7 +122,13 @@ const getRandomPostId = () => {
 const getAllPostFrontmatters = (): { id: string; frontmatter: PostFrontmatter }[] => {
   const frontmatterArray: { id: string; frontmatter: PostFrontmatter }[] = [];
   for (const mdxFilename of fs.readdirSync(POSTS_PATH)) {
-    const frontmatter = matter(fs.readFileSync(`${POSTS_PATH}/${mdxFilename}`, "utf8")).data;
+    const sourceText = fs.readFileSync(`${POSTS_PATH}/${mdxFilename}`, "utf8");
+
+    const frontmatter = {
+      ...matter(sourceText).data,
+      wordCount: sourceText.split(/\s+/gu).length,
+      readingTime: readingTime(sourceText).minutes,
+    };
 
     frontmatterArray.push({
       id: mdxFilename.split(".mdx")[0],

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -14,6 +14,8 @@ interface PostFrontmatter {
   author: string;
   description: string;
   tags: string[];
+  wordCount: number;
+  readingTime: number;
 }
 
 interface PortfolioItemFrontmatter {

--- a/src/pages/portfolio/PortfolioPage.tsx
+++ b/src/pages/portfolio/PortfolioPage.tsx
@@ -31,7 +31,7 @@ const PortfolioPage: React.FC<Props> = ({ portfolioItemsArray }) => {
   );
 };
 
-const getServerSideProps: GetServerSideProps = async () => {
+const getStaticProps: GetServerSideProps = async () => {
   return {
     props: {
       portfolioItemsArray: getAllPortfolioItems(),
@@ -39,5 +39,5 @@ const getServerSideProps: GetServerSideProps = async () => {
   };
 };
 
-export { getServerSideProps };
+export { getStaticProps };
 export default PortfolioPage;

--- a/src/pages/portfolio/index.tsx
+++ b/src/pages/portfolio/index.tsx
@@ -1,4 +1,4 @@
-import PortfolioPage, { getServerSideProps } from "./PortfolioPage";
+import PortfolioPage, { getStaticProps } from "./PortfolioPage";
 
 export default PortfolioPage;
-export { getServerSideProps };
+export { getStaticProps };

--- a/src/pages/posts/[id]/BlogPost.tsx
+++ b/src/pages/posts/[id]/BlogPost.tsx
@@ -5,6 +5,8 @@ import { GetStaticPropsContext } from "next";
 import Head from "next/head";
 import "rc-slider/assets/index.css"; // needed for rc-slider as used in the content-component PiEstimateVisualizer
 
+import { PostFrontmatter } from "@/interfaces";
+
 import { getPostById, getAllPostIds } from "../../../contentRetrieval/posts";
 import Layout from "../../../components/layout";
 import BlogHeader from "../../../components/blogHeader";
@@ -20,9 +22,7 @@ const colors = tailwindConfig.theme.colors;
 
 interface Props {
   code: string;
-  frontmatter: {
-    [key: string]: string | string[];
-  };
+  frontmatter: PostFrontmatter;
 }
 
 const BlogPost: React.FC<Props> = ({ code, frontmatter }) => {
@@ -56,13 +56,7 @@ const BlogPost: React.FC<Props> = ({ code, frontmatter }) => {
         </div>
         <article className="prose dark:prose-invert text-left pt-10 md:px-10 px-2 max-w-none md:max-w-[80%]">
           <header>
-            <BlogHeader
-              title={frontmatter.title as string}
-              datePublished={frontmatter.datePublished as string}
-              lastUpdated={frontmatter?.lastUpdated as string}
-              author={frontmatter.author as string}
-              tags={frontmatter.tags as string[]}
-            />
+            <BlogHeader postFrontmatter={frontmatter} />
           </header>
           <div className="mt-10">
             <PostComponent />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2111,6 +2111,11 @@ axobject-query@^3.1.1:
   dependencies:
     deep-equal "^2.0.5"
 
+b4a@^1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.6.4.tgz#ef1c1422cae5ce6535ec191baeed7567443f36c9"
+  integrity sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==
+
 babel-plugin-polyfill-corejs2@^0.3.3:
   version "0.3.3"
   resolved "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz"
@@ -2154,6 +2159,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 bcp-47-match@^2.0.0:
   version "2.0.3"
   resolved "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz"
@@ -2170,6 +2180,15 @@ bindings@^1.5.0:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
+
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 boolbase@^1.0.0:
   version "1.0.0"
@@ -2200,6 +2219,14 @@ browserslist@^4.21.3, browserslist@^4.21.5:
     electron-to-chromium "^1.4.284"
     node-releases "^2.0.8"
     update-browserslist-db "^1.0.10"
+
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
@@ -2301,6 +2328,11 @@ chokidar@^3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
+chownr@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
+
 classnames@^2.2.5, classnames@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
@@ -2330,10 +2362,26 @@ color-name@1.1.3:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-color-name@^1.1.4, color-name@~1.1.4:
+color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
+  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
+  dependencies:
+    color-convert "^2.0.1"
+    color-string "^1.9.0"
 
 comma-separated-tokens@^1.0.0:
   version "1.0.8"
@@ -2501,6 +2549,13 @@ decode-named-character-reference@^1.0.0:
   dependencies:
     character-entities "^2.0.0"
 
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
 deep-equal@^2.0.5:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.0.tgz#5caeace9c781028b9ff459f33b779346637c43e6"
@@ -2523,6 +2578,11 @@ deep-equal@^2.0.5:
     which-boxed-primitive "^1.0.2"
     which-collection "^1.0.1"
     which-typed-array "^1.1.9"
+
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@^0.1.3:
   version "0.1.4"
@@ -2556,6 +2616,11 @@ dequal@^2.0.0:
   version "2.0.3"
   resolved "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
+detect-libc@^2.0.0, detect-libc@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.2.tgz#8ccf2ba9315350e1241b88d0ac3b0e1fbd99605d"
+  integrity sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==
 
 detective@^5.2.1:
   version "5.2.1"
@@ -2646,6 +2711,13 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+end-of-stream@^1.1.0, end-of-stream@^1.4.1:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+  dependencies:
+    once "^1.4.0"
 
 enhanced-resolve@^5.10.0:
   version "5.12.0"
@@ -3188,6 +3260,11 @@ esutils@^2.0.2:
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+expand-template@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
+  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
@@ -3209,6 +3286,11 @@ fast-diff@^1.1.2:
   version "1.2.0"
   resolved "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
+
+fast-fifo@^1.1.0, fast-fifo@^1.2.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
+  integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
 fast-glob@^3.2.11, fast-glob@^3.2.12, fast-glob@^3.2.9:
   version "3.2.12"
@@ -3324,6 +3406,11 @@ fraction.js@^4.2.0:
   resolved "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz"
   integrity sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==
 
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
@@ -3393,6 +3480,11 @@ get-tsconfig@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.5.0.tgz#6d52d1c7b299bd3ee9cd7638561653399ac77b0f"
   integrity sha512-MjhiaIWCJ1sAU4pIQ5i5OfOuHHxVo1oYeNsWTON7jxYkod8pHocXeh+SSbmu5OZZZK73B6cbJ2XADzXehLyovQ==
+
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
+  integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
 
 github-slugger@^2.0.0:
   version "2.0.0"
@@ -3721,6 +3813,11 @@ hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   dependencies:
     react-is "^16.7.0"
 
+ieee754@^1.1.13:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
 ignore@^5.2.0:
   version "5.2.4"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz"
@@ -3752,10 +3849,15 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ini@~1.3.0:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 inline-style-parser@0.1.1:
   version "0.1.1"
@@ -3818,6 +3920,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-bigint@^1.0.1:
   version "1.0.4"
@@ -4912,6 +5019,11 @@ micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
@@ -4919,10 +5031,15 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
 mri@^1.1.0:
   version "1.2.0"
@@ -4953,6 +5070,11 @@ nanoid@^3.3.4:
   version "3.3.4"
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+
+napi-build-utils@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806"
+  integrity sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==
 
 natural-compare-lite@^1.4.0:
   version "1.4.0"
@@ -4995,6 +5117,18 @@ next@13.2.4:
     "@next/swc-win32-arm64-msvc" "13.2.4"
     "@next/swc-win32-ia32-msvc" "13.2.4"
     "@next/swc-win32-x64-msvc" "13.2.4"
+
+node-abi@^3.3.0:
+  version "3.51.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.51.0.tgz#970bf595ef5a26a271307f8a4befa02823d4e87d"
+  integrity sha512-SQkEP4hmNWjlniS5zdnfIXTk1x7Ome85RDzHlTbBtzE97Gfwz/Ipw4v/Ryk20DWIy3yCNVLVlGKApCnmvYoJbA==
+  dependencies:
+    semver "^7.3.5"
+
+node-addon-api@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-6.1.0.tgz#ac8470034e58e67d0c6f1204a18ae6995d9c0d76"
+  integrity sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==
 
 node-domexception@^1.0.0:
   version "1.0.0"
@@ -5110,7 +5244,7 @@ object.values@^1.1.5, object.values@^1.1.6:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -5346,6 +5480,24 @@ postcss@^8.0.9, postcss@^8.4.21:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+prebuild-install@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.1.tgz#de97d5b34a70a0c81334fd24641f2a1702352e45"
+  integrity sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==
+  dependencies:
+    detect-libc "^2.0.0"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^1.0.1"
+    node-abi "^3.3.0"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^4.0.0"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
@@ -5394,6 +5546,14 @@ property-information@^6.0.0:
   resolved "https://registry.npmjs.org/property-information/-/property-information-6.2.0.tgz"
   integrity sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==
 
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 punycode@^2.1.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz"
@@ -5403,6 +5563,11 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+queue-tick@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/queue-tick/-/queue-tick-1.0.1.tgz#f6f07ac82c1fd60f82e098b417a80e52f1f4c142"
+  integrity sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==
 
 quick-lru@^5.1.1:
   version "5.1.1"
@@ -5430,6 +5595,16 @@ rc-util@^5.27.0:
   dependencies:
     "@babel/runtime" "^7.18.3"
     react-is "^16.12.0"
+
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
 
 react-device-detect@^2.2.3:
   version "2.2.3"
@@ -5565,6 +5740,15 @@ read-cache@^1.0.0:
   integrity sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==
   dependencies:
     pify "^2.3.0"
+
+readable-stream@^3.1.1, readable-stream@^3.4.0:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -5889,6 +6073,11 @@ sade@^1.7.3:
   dependencies:
     mri "^1.1.0"
 
+safe-buffer@^5.0.1, safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 safe-regex-test@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz"
@@ -5918,12 +6107,33 @@ semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.3.5, semver@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@^7.3.7:
   version "7.3.8"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
+
+sharp@^0.32.6:
+  version "0.32.6"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.32.6.tgz#6ad30c0b7cd910df65d5f355f774aa4fce45732a"
+  integrity sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==
+  dependencies:
+    color "^4.2.3"
+    detect-libc "^2.0.2"
+    node-addon-api "^6.1.0"
+    prebuild-install "^7.1.1"
+    semver "^7.5.4"
+    simple-get "^4.0.1"
+    tar-fs "^3.0.4"
+    tunnel-agent "^0.6.0"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -5945,6 +6155,27 @@ side-channel@^1.0.4:
     call-bind "^1.0.0"
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
+
+simple-concat@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^4.0.0, simple-get@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
+  dependencies:
+    is-arrayish "^0.3.1"
 
 slash@^3.0.0:
   version "3.0.0"
@@ -5988,6 +6219,14 @@ stop-iteration-iterator@^1.0.0:
   dependencies:
     internal-slot "^1.0.4"
 
+streamx@^2.15.0:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.15.1.tgz#396ad286d8bc3eeef8f5cea3f029e81237c024c6"
+  integrity sha512-fQMzy2O/Q47rgwErk/eGeLu/roaFWV0jVsogDmrszM9uIw8L5OA+t+V93MgYlufNptfjmYR1tOMWhei/Eh7TQA==
+  dependencies:
+    fast-fifo "^1.1.0"
+    queue-tick "^1.0.1"
+
 string.prototype.matchall@^4.0.7, string.prototype.matchall@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz#3bf85722021816dcd1bf38bb714915887ca79fd3"
@@ -6020,6 +6259,13 @@ string.prototype.trimstart@^1.0.6:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
 stringify-entities@^4.0.0:
   version "4.0.3"
   resolved "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.3.tgz"
@@ -6049,6 +6295,11 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
 style-to-object@^0.4.0, style-to-object@^0.4.1:
   version "0.4.1"
@@ -6149,6 +6400,45 @@ tapable@^2.2.0:
   resolved "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
+tar-fs@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
+tar-fs@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.0.4.tgz#a21dc60a2d5d9f55e0089ccd78124f1d3771dbbf"
+  integrity sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==
+  dependencies:
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^3.1.5"
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+
+tar-stream@^3.1.5:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-3.1.6.tgz#6520607b55a06f4a2e2e04db360ba7d338cc5bab"
+  integrity sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==
+  dependencies:
+    b4a "^1.6.4"
+    fast-fifo "^1.2.0"
+    streamx "^2.15.0"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
@@ -6220,6 +6510,13 @@ tsutils@^3.21.0:
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -6407,7 +6704,7 @@ use-sync-external-store@^1.0.0:
   resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
-util-deprecate@^1.0.2:
+util-deprecate@^1.0.1, util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==


### PR DESCRIPTION
# Why are you making this PR?

To create a more useful README than the previous one (which basically just included the project's name and that it was live). This file now includes an overview of the project, information about how I structured its files and also steps someone could follow to create a blog of their own using my code as a template.

# What else did you do?
- Included my copyright notice in the LICENSE.
- Included reading-time estimates in blog-post search items and blog-post headers.
- Portfolio items are now pre-rendered via [`getStaticProps()`](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-static-props) rather than [`getServerSideProps()`](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props) since they don't actually have to be re-pre-rendered after each request.
- Added the [`sharp`](https://github.com/lovell/sharp) library for (hopefully) faster SVG rendering in production 🤞. [Image optimization in Next.js requires this library](https://nextjs.org/docs/messages/install-sharp).